### PR TITLE
fix: include all necessary runtime deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,13 +8,13 @@ workflows:
   workflow:
     jobs:
       - build:
-          context: npm
+          context: npm-readonly
           filters:
             branches:
               ignore:
                 - main
       - build:
-          context: npm
+          context: npm-publish
           publish: true
           filters:
             branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "better-apollo-mocked-provider",
+  "name": "@homebound/better-apollo-mocked-provider",
   "version": "1.0.0-bump",
   "lockfileVersion": 1,
   "requires": true,
@@ -21,6 +21,16 @@
         "ts-invariant": "^0.4.4",
         "tslib": "^1.10.0",
         "zen-observable": "^0.8.14"
+      },
+      "dependencies": {
+        "ts-invariant": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
+          "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@babel/code-frame": {
@@ -2584,9 +2594,19 @@
       "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
     },
     "graphql-tag": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "requires": {
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "growly": {
       "version": "1.3.0",
@@ -6461,11 +6481,18 @@
       }
     },
     "ts-invariant": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.4.4.tgz",
-      "integrity": "sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.2.tgz",
+      "integrity": "sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "ts-jest": {

--- a/package.json
+++ b/package.json
@@ -33,9 +33,11 @@
   },
   "dependencies": {
     "@apollo/client": "^3.1.3",
+    "fast-json-stable-stringify": "^2.1.0",
     "graphql": "^15.3.0",
     "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react-dom": "^16.12.0",
+    "ts-invariant": "^0.10.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
@@ -43,6 +45,7 @@
     "@types/jest": "^25.2.3",
     "@types/node": "12.12.3",
     "@types/react": "16.9.11",
+    "graphql-tag": "^2.12.6",
     "husky": "^4.2.5",
     "jest": "^26.4.2",
     "lint-staged": "^10.1.2",


### PR DESCRIPTION
This PR adds a few `dependencies` to `package.json`. This will prevent runtime errors when folks just `npm install` this package.